### PR TITLE
SoftwareSerial.h path fix

### DIFF
--- a/PololuQik/PololuQik.h
+++ b/PololuQik/PololuQik.h
@@ -2,7 +2,7 @@
 #define PololuQik_h
 
 #include <Arduino.h>
-#include "../SoftwareSerial/SoftwareSerial.h"
+#include <SoftwareSerial.h>
 
 // Commands
 


### PR DESCRIPTION
SoftwareSerial.h is now baseline with the Arduino IDE and the previous path is no longer functional/necessary.
